### PR TITLE
Fix verify-common-name datatype

### DIFF
--- a/openvpn_auth_azure_ad/authenticator.py
+++ b/openvpn_auth_azure_ad/authenticator.py
@@ -145,7 +145,7 @@ class AADAuthenticator(object):
             )
 
     def verify_client_certificate(self, client, result) -> bool:
-        if self._verify_certificate_claim == False:
+        if not self._verify_certificate_claim:
             return True
 
         if "common_name" not in client["env"]:

--- a/openvpn_auth_azure_ad/authenticator.py
+++ b/openvpn_auth_azure_ad/authenticator.py
@@ -43,7 +43,7 @@ class AADAuthenticator(object):
         app: PublicClientApplication,
         graph_endpoint: str,
         authenticators: str,
-        verify_certificate_claim: str,
+        verify_certificate_claim: bool,
         auth_token: bool,
         auth_token_lifetime: int,
         remember_user: bool,
@@ -145,7 +145,7 @@ class AADAuthenticator(object):
             )
 
     def verify_client_certificate(self, client, result) -> bool:
-        if self._verify_certificate_claim == "":
+        if self._verify_certificate_claim == False:
             return True
 
         if "common_name" not in client["env"]:


### PR DESCRIPTION
Per cli.py, this is parsed as a boolean. https://github.com/jkroepke/openvpn-auth-azure-ad/blob/2bb6af7ca82757da5dd8b3fbd72cee6670a7aaa9/openvpn_auth_azure_ad/cli.py#L72

Which errors with logic/datatype mismatches in authenticator.py treating it as a string.

`--verify-common-name` is the 4th argument to `AADAuthenticator`, https://github.com/jkroepke/openvpn-auth-azure-ad/blob/2bb6af7ca82757da5dd8b3fbd72cee6670a7aaa9/openvpn_auth_azure_ad/cli.py#L181 which correlates to verify_certificate_claim https://github.com/jkroepke/openvpn-auth-azure-ad/blob/2bb6af7ca82757da5dd8b3fbd72cee6670a7aaa9/openvpn_auth_azure_ad/authenticator.py#L46