### PR TITLE
Bypass AzureAD login based in cert CN attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ optional arguments:
                         Amount of threads to handle authentication [env var: AAD_THREAD_COUNT]
 
 OpenVPN User Authentication:
+  --bypass-cns BYPASS_CNS
+                        Comma separated common names to bypass Azure AD login (cert only authentication)
   -a AUTHENTICATORS, --authenticators AUTHENTICATORS
                         Enable authenticators. Multiple authenticators can be separated with comma [env var: AAD_AUTHENTICATORS]
   --auth-token          Use auth token to re-authenticate clients [env var: AAD_AUTH_TOKEN]

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Use `auth-gen-token` only on OpenVPN 2.5+. It conflicts with `--auth-token`.
 management socket-name unix [pw-file]
 management-hold
 management-client-auth
+auth-user-pass-optional #To enable Bypass Cert Common Name for Certain Users not login in through AzureAD
 ```
 
 See [Reference manual for OpenVPN](https://openvpn.net/community-resources/reference-manual-for-openvpn-2-4/)

--- a/openvpn_auth_azure_ad/__init__.py
+++ b/openvpn_auth_azure_ad/__init__.py
@@ -42,6 +42,12 @@ def main():
     )
 
     parser_authentication = parser.add_argument_group("OpenVPN User Authentication")
+    
+    parser_authentication.add_argument(
+        '--bypass-cns',
+        help='Comma separated common names to bypass Azure AD login (cert only authentication)',
+    )
+
     parser_authentication.add_argument(
         "-a",
         "--authenticators",
@@ -200,6 +206,7 @@ def main():
         app,
         options.graph_endpoint,
         options.authenticators,
+        options.bypass_cns,
         options.openvpn_identity_key,
         options.verify_openvpn_client,
         options.verify_openvpn_client_id_token_claim,


### PR DESCRIPTION
Hi, recently I had to use this auth plugin for OpenVPN and it has worked flawlessly. I was put up to the challenge to authenticate users in O365 but also let certain servers bypass the AzureAD login requirement without the input of the user/pwd. I came up with a pre-filter in the authenticate method where a comma-delimited string containing the CNs that will be allowed to bypass the AzureAD login requirement is used and if it matches it checks the cert and lets it connect if it's good. IDK if this is something useful that you would like to merge into your repo and published module but I just want to contribute in case someone else wants this feature.